### PR TITLE
Upgrade Three.js to r182 with API compatibility fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "dat.gui": "0.7.6",
-    "three": "0.113.0",
+    "three": "0.182.0",
     "yuka": "0.7.0"
   }
 }

--- a/src/core/AssetManager.js
+++ b/src/core/AssetManager.js
@@ -1,6 +1,6 @@
 import { LoadingManager, AnimationLoader, AudioLoader, TextureLoader, Mesh } from 'three';
 import { Sprite, SpriteMaterial, DoubleSide, AudioListener, PositionalAudio } from 'three';
-import { LineSegments, LineBasicMaterial, MeshBasicMaterial, BufferGeometry, Vector3, PlaneBufferGeometry } from 'three';
+import { LineSegments, LineBasicMaterial, MeshBasicMaterial, BufferGeometry, Vector3, PlaneGeometry } from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { NavMeshLoader, CostTable } from 'yuka';
 import { CONFIG } from './Config.js';
@@ -294,7 +294,7 @@ class AssetManager {
 		// shadow for soldiers
 
 		const shadowTexture = textureLoader.load( './textures/shadow.png' );
-		const planeGeometry = new PlaneBufferGeometry();
+		const planeGeometry = new PlaneGeometry();
 		const planeMaterial = new MeshBasicMaterial( { map: shadowTexture, transparent: true, opacity: 0.4 } );
 
 		const shadowPlane = new Mesh( planeGeometry, planeMaterial );

--- a/src/core/World.js
+++ b/src/core/World.js
@@ -1,5 +1,5 @@
 import { EntityManager, Time, MeshGeometry, Vector3, CellSpacePartitioning } from 'yuka';
-import { WebGLRenderer, Scene, PerspectiveCamera, Color, AnimationMixer, Object3D, SkeletonHelper, sRGBEncoding } from 'three';
+import { WebGLRenderer, Scene, PerspectiveCamera, Color, AnimationMixer, Object3D, SkeletonHelper, SRGBColorSpace } from 'three';
 import { HemisphereLight, DirectionalLight } from 'three';
 import { AxesHelper } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
@@ -340,7 +340,7 @@ class World {
 		this.renderer.setSize( window.innerWidth, window.innerHeight );
 		this.renderer.autoClear = false;
 		this.renderer.shadowMap.enabled = true;
-		this.renderer.outputEncoding = sRGBEncoding;
+		this.renderer.outputColorSpace = SRGBColorSpace;
 		document.body.appendChild( this.renderer.domElement );
 
 		// event listeners

--- a/src/effects/Sky.js
+++ b/src/effects/Sky.js
@@ -1,4 +1,4 @@
-import { ShaderMaterial, UniformsUtils, BackSide, Mesh, BoxBufferGeometry, Vector3 } from 'three';
+import { ShaderMaterial, UniformsUtils, BackSide, Mesh, BoxGeometry, Vector3 } from 'three';
 
 /**
 * Reference: https://github.com/mrdoob/three.js/blob/master/examples/js/objects/Sky.js
@@ -16,7 +16,7 @@ class Sky extends Mesh {
 			side: BackSide
 		} );
 
-		super( new BoxBufferGeometry( 1, 1, 1 ), material );
+		super( new BoxGeometry( 1, 1, 1 ), material );
 
 	}
 
@@ -25,7 +25,7 @@ class Sky extends Mesh {
 const SkyShader = {
 
 	uniforms: {
-		'luminance': { value: 1 },
+		'skyLuminance': { value: 1 },
 		'turbidity': { value: 2 },
 		'rayleigh': { value: 1 },
 		'mieCoefficient': { value: 0.005 },
@@ -115,7 +115,7 @@ const SkyShader = {
 		'varying vec3 vBetaM;',
 		'varying float vSunE;',
 
-		'uniform float luminance;',
+		'uniform float skyLuminance;',
 		'uniform float mieDirectionalG;',
 
 		'const vec3 cameraPos = vec3( 0.0, 0.0, 0.0 );',
@@ -199,7 +199,7 @@ const SkyShader = {
 
 		'	vec3 texColor = ( Lin + L0 ) * 0.04 + vec3( 0.0, 0.0003, 0.00075 );',
 
-		'	vec3 curr = Uncharted2Tonemap( ( log2( 2.0 / pow( luminance, 4.0 ) ) ) * texColor );',
+		'	vec3 curr = Uncharted2Tonemap( ( log2( 2.0 / pow( skyLuminance, 4.0 ) ) ) * texColor );',
 		'	vec3 color = curr * whiteScale;',
 
 		'	vec3 retColor = pow( color, vec3( 1.0 / ( 1.2 + ( 1.2 * vSunfade ) ) ) );',

--- a/src/etc/CharacterBounds.js
+++ b/src/etc/CharacterBounds.js
@@ -62,13 +62,13 @@ class CharacterBounds {
 		const headBone = renderComponent.getObjectByName( 'Armature_mixamorigHead' );
 		const head = new AABB( new Vector3( - 0.1, 1.6, - 0.1 ), new Vector3( 0.1, 1.8, 0.1 ) );
 		let bindMatrix = new Matrix4().copy( headBone.matrixWorld );
-		let bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		let bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: head, bone: headBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		const spineBone = renderComponent.getObjectByName( 'Armature_mixamorigSpine1' );
 		const spine = new AABB( new Vector3( - 0.2, 1, - 0.2 ), new Vector3( 0.2, 1.6, 0.2 ) );
 		bindMatrix = new Matrix4().copy( spineBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: spine, bone: spineBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		// arms
@@ -76,25 +76,25 @@ class CharacterBounds {
 		const rightArmBone = renderComponent.getObjectByName( 'Armature_mixamorigRightArm' );
 		const rightArm = new AABB( new Vector3( - 0.4, 1.42, - 0.15 ), new Vector3( - 0.2, 1.58, 0.1 ) );
 		bindMatrix = new Matrix4().copy( rightArmBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: rightArm, bone: rightArmBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		const rightForeArmBone = renderComponent.getObjectByName( 'Armature_mixamorigRightForeArm' );
 		const rightForeArm = new AABB( new Vector3( - 0.8, 1.42, - 0.15 ), new Vector3( - 0.4, 1.55, 0.05 ) );
 		bindMatrix = new Matrix4().copy( rightForeArmBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: rightForeArm, bone: rightForeArmBone, bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		const leftArmBone = renderComponent.getObjectByName( 'Armature_mixamorigLeftArm' );
 		const leftArm = new AABB( new Vector3( 0.2, 1.42, - 0.15 ), new Vector3( 0.4, 1.58, 0.1 ) );
 		bindMatrix = new Matrix4().copy( leftArmBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: leftArm, bone: leftArmBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		const leftForeArmBone = renderComponent.getObjectByName( 'Armature_mixamorigLeftForeArm' );
 		const leftForeArm = new AABB( new Vector3( 0.4, 1.42, - 0.15 ), new Vector3( 0.8, 1.55, 0.05 ) );
 		bindMatrix = new Matrix4().copy( leftForeArmBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: leftForeArm, bone: leftForeArmBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		// legs
@@ -102,25 +102,25 @@ class CharacterBounds {
 		const rightUpLegBone = renderComponent.getObjectByName( 'Armature_mixamorigRightUpLeg' );
 		const rightUpLeg = new AABB( new Vector3( - 0.2, 0.6, - 0.15 ), new Vector3( 0, 1, 0.15 ) );
 		bindMatrix = new Matrix4().copy( rightUpLegBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: rightUpLeg, bone: rightUpLegBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		const rightLegBone = renderComponent.getObjectByName( 'Armature_mixamorigRightLeg' );
 		const rightLeg = new AABB( new Vector3( - 0.2, 0, - 0.15 ), new Vector3( 0, 0.6, 0.15 ) );
 		bindMatrix = new Matrix4().copy( rightLegBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: rightLeg, bone: rightLegBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		const leftUpLegBone = renderComponent.getObjectByName( 'Armature_mixamorigLeftUpLeg' );
 		const leftUpLeg = new AABB( new Vector3( 0, 0.6, - 0.15 ), new Vector3( 0.2, 1, 0.15 ) );
 		bindMatrix = new Matrix4().copy( leftUpLegBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: leftUpLeg, bone: leftUpLegBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		const leftLegBone = renderComponent.getObjectByName( 'Armature_mixamorigLeftLeg' );
 		const leftLeg = new AABB( new Vector3( 0, 0, - 0.15 ), new Vector3( 0.2, 0.6, 0.15 ) );
 		bindMatrix = new Matrix4().copy( leftLegBone.matrixWorld );
-		bindMatrixInverse = new Matrix4().getInverse( bindMatrix );
+		bindMatrixInverse = new Matrix4().copy( bindMatrix ).invert();
 		hitboxes.push( { aabb: leftLeg, bone: leftLegBone, bindMatrix: bindMatrix, bindMatrixInverse: bindMatrixInverse } );
 
 		//
@@ -237,7 +237,7 @@ class CharacterBounds {
 
 		if ( entry === undefined ) {
 
-			entry = { tick: tick, inverseBoneMatrix: new Matrix4().getInverse( bone.matrixWorld ) };
+			entry = { tick: tick, inverseBoneMatrix: new Matrix4().copy( bone.matrixWorld ).invert() };
 			this._cache.set( bone, entry );
 
 
@@ -246,7 +246,7 @@ class CharacterBounds {
 			if ( entry.tick < tick ) {
 
 				entry.tick = tick;
-				entry.inverseBoneMatrix.getInverse( bone.matrixWorld );
+				entry.inverseBoneMatrix.copy( bone.matrixWorld ).invert();
 
 			} else {
 

--- a/src/etc/NavMeshUtils.js
+++ b/src/etc/NavMeshUtils.js
@@ -1,7 +1,7 @@
 import { LineSegments, Line, Mesh, Group } from 'three';
 import { MeshBasicMaterial, LineBasicMaterial } from 'three';
-import { BufferGeometry, Float32BufferAttribute, IcosahedronBufferGeometry } from 'three';
-import { Color, VertexColors } from 'three';
+import { BufferGeometry, Float32BufferAttribute, IcosahedronGeometry } from 'three';
+import { Color } from 'three';
 
 /**
 * Class with various helpers in context of navigation meshes.
@@ -22,7 +22,7 @@ class NavMeshUtils {
 		const regions = navMesh.regions;
 
 		const geometry = new BufferGeometry();
-		const material = new MeshBasicMaterial( { vertexColors: VertexColors, depthWrite: false, polygonOffset: true, polygonOffsetFactor: - 4 } );
+		const material = new MeshBasicMaterial( { vertexColors: true, depthWrite: false, polygonOffset: true, polygonOffsetFactor: - 4 } );
 
 		const mesh = new Mesh( geometry, material );
 		mesh.matrixAutoUpdate = false;
@@ -114,7 +114,7 @@ class NavMeshUtils {
 		// nodes
 
 		const nodeMaterial = new MeshBasicMaterial( { color: nodeColor } );
-		const nodeGeometry = new IcosahedronBufferGeometry( nodeSize, 2 );
+		const nodeGeometry = new IcosahedronGeometry( nodeSize, 2 );
 
 		const nodes = [];
 

--- a/src/etc/SceneUtils.js
+++ b/src/etc/SceneUtils.js
@@ -1,5 +1,5 @@
 import { LineSegments, Sprite, SpriteMaterial, LineBasicMaterial, CanvasTexture, BufferGeometry, Float32BufferAttribute } from 'three';
-import { Mesh, Group, MeshBasicMaterial, CylinderBufferGeometry, SphereBufferGeometry } from 'three';
+import { Mesh, Group, MeshBasicMaterial, CylinderGeometry, SphereGeometry } from 'three';
 
 /**
 * Class with various helper methods.
@@ -133,7 +133,7 @@ class SceneUtils {
 
 		const nodeColor = 0xff0000;
 		const nodeMaterial = new MeshBasicMaterial( { color: nodeColor } );
-		const nodeGeometry = new CylinderBufferGeometry( 0.2, 0.2, 0.5 );
+		const nodeGeometry = new CylinderGeometry( 0.2, 0.2, 0.5 );
 		nodeGeometry.translate( 0, 0.25, 0 );
 
 		for ( let i = 0, l = spawnPoints.length; i < l; i ++ ) {
@@ -165,7 +165,7 @@ class SceneUtils {
 
 		// assuming trigger.region is of type SphericalTriggerRegion
 
-		const triggerGeometry = new SphereBufferGeometry( trigger.region.radius, 16, 16 );
+		const triggerGeometry = new SphereGeometry( trigger.region.radius, 16, 16 );
 		const triggerMaterial = new MeshBasicMaterial( { color: 0x6083c2, wireframe: true } );
 
 		const triggerMesh = new Mesh( triggerGeometry, triggerMaterial );


### PR DESCRIPTION
Hi, Ive been playing around with this project to make it VR compatible, ill probably open source what im building at some point but from now, Id like to contribute with what I had too do to make this work with the latest version of threejs.

This has been mostly generated by Claude I wont lie but Ive tested all myself and it works as expected from my point of view.

====================

# Upgrade Three.js to r182

This PR updates Three.js from v0.113.0 to v0.182.0 and fixes all deprecated API usages.

## Changes

### package.json
- Updated `three` dependency from `0.113.0` to `^0.182.0`

### Deprecated Geometry Classes
The `*BufferGeometry` classes were merged with their non-Buffer counterparts in Three.js r125:

- `src/effects/Sky.js`: `BoxBufferGeometry` → `BoxGeometry`
- `src/core/AssetManager.js`: `PlaneBufferGeometry` → `PlaneGeometry`
- `src/etc/SceneUtils.js`: `CylinderBufferGeometry` → `CylinderGeometry`, `SphereBufferGeometry` → `SphereGeometry`
- `src/etc/NavMeshUtils.js`: `IcosahedronBufferGeometry` → `IcosahedronGeometry`

### Matrix4.getInverse() Removal
`Matrix4.getInverse(matrix)` was deprecated in r123 and removed in r155. Replaced with `copy(matrix).invert()`:

- `src/etc/CharacterBounds.js`: All 12 occurrences updated

### Color Space API Changes
The encoding properties were renamed in r152:

- `src/core/World.js`: `sRGBEncoding` → `SRGBColorSpace`, `outputEncoding` → `outputColorSpace`

### GLSL Reserved Word Conflict
`luminance` became a reserved word in GLSL with newer Three.js shader compilation:

- `src/effects/Sky.js`: Renamed uniform from `luminance` to `skyLuminance`

### VertexColors Constant Removal
The `VertexColors` constant was removed in r128:

- `src/etc/NavMeshUtils.js`: `vertexColors: VertexColors` → `vertexColors: true`

## Testing
- Verified game loads and renders correctly with no console errors
- All visual elements (arena, sky, debug overlays) render as expected